### PR TITLE
EC-740 Indicate guidance is draft

### DIFF
--- a/Comments/ClientApp/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/Comments/ClientApp/src/components/Breadcrumbs/Breadcrumbs.js
@@ -47,12 +47,10 @@ export class Breadcrumbs extends PureComponent<PropsType> {
 								onClick={()=>this.trackBreadcrumb(segment)}
 							>
 								{(isHttpLink(url) || (url.indexOf("/") === 0 && !localRoute)) ?
-									<a href={url} itemProp="item">
-										<span itemprop="name">{label}</span>
-									</a>
+									<a href={url}>{label}</a>
 									:
-									<Link to={url} itemProp="item">
-										<span itemprop="name">{label}</span>
+									<Link to={url} itemProp="name">
+										{label}
 									</Link>
 								}
 								<meta itemProp="position" content={index}/>

--- a/Comments/ClientApp/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/Comments/ClientApp/src/components/Breadcrumbs/Breadcrumbs.js
@@ -47,10 +47,12 @@ export class Breadcrumbs extends PureComponent<PropsType> {
 								onClick={()=>this.trackBreadcrumb(segment)}
 							>
 								{(isHttpLink(url) || (url.indexOf("/") === 0 && !localRoute)) ?
-									<a href={url}>{label}</a>
+									<a href={url} itemProp="item">
+										<span itemprop="name">{label}</span>
+									</a>
 									:
-									<Link to={url} itemProp="name">
-										{label}
+									<Link to={url} itemProp="item">
+										<span itemprop="name">{label}</span>
 									</Link>
 								}
 								<meta itemProp="position" content={index}/>

--- a/Comments/ClientApp/src/components/Document/Document.js
+++ b/Comments/ClientApp/src/components/Document/Document.js
@@ -43,6 +43,7 @@ type StateType = {
 		slug: string
 	},
 	allowComments: boolean,
+	consultationIsOpen: boolean,
 	error: ErrorType,
 };
 
@@ -61,6 +62,7 @@ export class Document extends Component<PropsType, StateType> {
 			currentInPageNavItem: null,
 			onboarded: false,
 			allowComments: true,
+			consultationIsOpen: true,
 			children: null,
 			error: {
 				hasError: false,
@@ -112,6 +114,8 @@ export class Document extends Component<PropsType, StateType> {
 					preloadedConsultation.consultationState.consultationIsOpen &&
 					!preloadedConsultation.consultationState.userHasSubmitted;
 
+				const consultationIsOpen = preloadedConsultation.consultationState.consultationIsOpen;
+
 				if (preloadedChapter) {
 					preloadedChapter = this.addChapterDetailsToSections(preloadedChapter);
 				}
@@ -124,6 +128,7 @@ export class Document extends Component<PropsType, StateType> {
 					currentInPageNavItem: null,
 					onboarded: false,
 					allowComments,
+					consultationIsOpen,
 					error: {
 						hasError: false,
 						message: null,
@@ -195,12 +200,14 @@ export class Document extends Component<PropsType, StateType> {
 						data.consultationData.consultationState.hasAnyDocumentsSupportingComments &&
 						data.consultationData.consultationState.consultationIsOpen &&
 						!data.consultationData.consultationState.userHasSubmitted;
+					const consultationIsOpen = data.consultationData.consultationState.consultationIsOpen;
 					this.addChapterDetailsToSections(data.chapterData);
 					this.setState({
 						...data,
 						loading: false,
 						hasInitialData: true,
 						allowComments: allowComments,
+						consultationIsOpen: consultationIsOpen,
 					}, () => {
 						tagManager({
 							event: "pageview",
@@ -411,6 +418,7 @@ export class Document extends Component<PropsType, StateType> {
 			onNewCommentClick: this.props.onNewCommentClick,
 			url: this.props.match.url,
 			allowComments: this.state.allowComments,
+			consultationIsOpen: this.state.consultationIsOpen,
 		};
 
 		const supportingDocs = this.getDocumentLinks(
@@ -440,6 +448,11 @@ export class Document extends Component<PropsType, StateType> {
 					<div className="grid">
 						<div data-g="12">
 							<BreadCrumbsWithRouter links={this.state.consultationData.breadcrumbs}/>
+							{!this.state.consultationIsOpen &&
+								<div className="caution">
+									<strong>The content on this page is not current guidance and is only for the purposes of the consultation process.</strong>
+								</div>
+							}
 							<main role="main">
 								<div className="page-header">
 									<Header
@@ -472,6 +485,7 @@ export class Document extends Component<PropsType, StateType> {
 									</button>
 									}
 								</div>
+
 
 								<button
 									className="screenreader-button"

--- a/Comments/ClientApp/src/components/Document/Document.js
+++ b/Comments/ClientApp/src/components/Document/Document.js
@@ -43,7 +43,6 @@ type StateType = {
 		slug: string
 	},
 	allowComments: boolean,
-	consultationIsOpen: boolean,
 	error: ErrorType,
 };
 
@@ -62,7 +61,6 @@ export class Document extends Component<PropsType, StateType> {
 			currentInPageNavItem: null,
 			onboarded: false,
 			allowComments: true,
-			consultationIsOpen: true,
 			children: null,
 			error: {
 				hasError: false,
@@ -114,7 +112,6 @@ export class Document extends Component<PropsType, StateType> {
 					preloadedConsultation.consultationState.consultationIsOpen &&
 					!preloadedConsultation.consultationState.userHasSubmitted;
 
-				const consultationIsOpen = preloadedConsultation.consultationState.consultationIsOpen;
 
 				if (preloadedChapter) {
 					preloadedChapter = this.addChapterDetailsToSections(preloadedChapter);
@@ -128,7 +125,6 @@ export class Document extends Component<PropsType, StateType> {
 					currentInPageNavItem: null,
 					onboarded: false,
 					allowComments,
-					consultationIsOpen,
 					error: {
 						hasError: false,
 						message: null,
@@ -200,14 +196,12 @@ export class Document extends Component<PropsType, StateType> {
 						data.consultationData.consultationState.hasAnyDocumentsSupportingComments &&
 						data.consultationData.consultationState.consultationIsOpen &&
 						!data.consultationData.consultationState.userHasSubmitted;
-					const consultationIsOpen = data.consultationData.consultationState.consultationIsOpen;
 					this.addChapterDetailsToSections(data.chapterData);
 					this.setState({
 						...data,
 						loading: false,
 						hasInitialData: true,
 						allowComments: allowComments,
-						consultationIsOpen: consultationIsOpen,
 					}, () => {
 						tagManager({
 							event: "pageview",
@@ -418,7 +412,6 @@ export class Document extends Component<PropsType, StateType> {
 			onNewCommentClick: this.props.onNewCommentClick,
 			url: this.props.match.url,
 			allowComments: this.state.allowComments,
-			consultationIsOpen: this.state.consultationIsOpen,
 		};
 
 		const supportingDocs = this.getDocumentLinks(
@@ -448,7 +441,7 @@ export class Document extends Component<PropsType, StateType> {
 					<div className="grid">
 						<div data-g="12">
 							<BreadCrumbsWithRouter links={this.state.consultationData.breadcrumbs}/>
-							{!this.state.consultationIsOpen &&
+							{!this.state.consultationData.consultationState.consultationIsOpen &&
 								<div className="caution">
 									<strong>The content on this page is not current guidance and is only for the purposes of the consultation process.</strong>
 								</div>

--- a/Comments/ClientApp/src/components/Document/Document.scss
+++ b/Comments/ClientApp/src/components/Document/Document.scss
@@ -45,6 +45,13 @@
   }
 }
 
+.caution {
+  background-color: $colour-caution-our-version;
+  border: 2px solid black ;
+  display: inline-block;
+  padding: 10px;
+}
+
 .visuallyhidden { 
   position: absolute; 
   overflow: hidden; 

--- a/Comments/ClientApp/src/components/Document/Document.scss
+++ b/Comments/ClientApp/src/components/Document/Document.scss
@@ -47,9 +47,9 @@
 
 .caution {
   background-color: $colour-caution-our-version;
-  border: 2px solid black ;
+  border: em($spacing-xx-small) solid black;
   display: inline-block;
-  padding: 10px;
+  padding: 	rem($spacing-small);
 }
 
 .visuallyhidden { 

--- a/Comments/ClientApp/src/components/Document/__tests__/Document.test.js
+++ b/Comments/ClientApp/src/components/Document/__tests__/Document.test.js
@@ -230,6 +230,57 @@ describe("[ClientApp] ", () => {
 					},
 				]);
 			});
+
+			it("should not caution that guidance is draft if the consultation is open", () => {
+				const mock = new MockAdapter(axios);
+	
+				const wrapper = mount(
+					<MemoryRouter>
+						<Document {...fakeProps} />
+					</MemoryRouter>
+				);
+	
+				let documentsPromise = new Promise(resolve => {
+					mock
+						.onGet("/consultations/api/Documents?consultationId=1")
+						.reply(() => {
+							resolve();
+							return [200, DocumentsData];
+						});
+				});
+
+				let consulatationPromise = new Promise(resolve => {
+					mock
+						.onGet("/consultations/api/Consultation?consultationId=1&isReview=false")
+						.reply(() => {
+							resolve();
+							return [200, ConsultationData];
+						});
+				});
+	
+				let chapterPromise = new Promise(resolve => {
+					mock
+						.onGet(
+							"/consultations/api/Chapter?consultationId=1&documentId=1&chapterSlug=introduction"
+						)
+						.reply(() => {
+							resolve();
+							return [200, ChapterData];
+						});
+				});
+	
+				return Promise.all([
+					documentsPromise,
+					consulatationPromise,
+					chapterPromise,
+				]).then(async () => {
+					await nextTick();
+					wrapper.update();
+	
+					expect(wrapper.find(".caution").length).toEqual(0);
+	
+				});
+			});
 		});
 	});
 });


### PR DESCRIPTION
When guidance is no longer in consultation, we should indicate that it is draft and not final guidance so that users who come across it don't confuse it for the finalised guidance.