### PR TITLE
EC-817 Removed "for info only" from support docs

### DIFF
--- a/Comments/ClientApp/src/components/Document/Document.js
+++ b/Comments/ClientApp/src/components/Document/Document.js
@@ -415,7 +415,7 @@ export class Document extends Component<PropsType, StateType> {
 
 		const supportingDocs = this.getDocumentLinks(
 			false,
-			"Supporting documents (for information only)",
+			"Supporting documents",
 			documentsData,
 			documentId,
 			consultationId


### PR DESCRIPTION
Removed the words "for information only" from the supporting docs navigation - it is unnecessary and can be confusing if we ask questions about the documents there.